### PR TITLE
Add System Resource Monitoring SSE Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A real-time web scraping and content parsing demo using Django Server-Sent Event
 - **Server-Sent Events**: Real-time streaming updates
 - **React Frontend**: Modern UI with real-time message display
 - **Docker Support**: Containerized deployment
+- **Real-time System Monitoring**: Streams CPU and memory usage.
 
 ## Quick Start
 
@@ -41,6 +42,7 @@ docker-compose up --build
 - `GET /api/sse-demo` - Basic SSE demo
 - `GET /api/sse-demo-2` - Simple SSE demo (simulated web search)
 - `GET /api/sse-demo-3` - **Real web scraping SSE demo** (fetches real websites)
+- `GET /api/sse-system-stats` - System resource monitoring demo (CPU, Memory).
 
 ## Web Scraping Demo
 
@@ -53,6 +55,19 @@ The `/api/sse-demo-3` endpoint:
 ### Test with curl:
 ```bash
 curl -N http://localhost:8000/api/sse-demo-3
+```
+
+## System Resource Monitoring Demo
+
+The `/api/sse-system-stats` endpoint provides a real-time stream of server system metrics:
+- Overall CPU utilization percentage.
+- Per-core CPU utilization percentages.
+- Memory usage percentage.
+- Updates are streamed every second.
+
+### Test with curl:
+```bash
+curl -N http://localhost:8000/api/sse-system-stats
 ```
 
 ## Project Structure

--- a/core/sse_demo_4.py
+++ b/core/sse_demo_4.py
@@ -21,8 +21,7 @@ def system_stats_event_generator():
         }
 
         # SSE format: event: <type>
-data: <json_string>
-
+        # data: <json_string>
 
         yield f"event: system_stats\ndata: {json.dumps(data)}\n\n"
         # No need for additional time.sleep here as psutil.cpu_percent(interval=1) already introduces a delay

--- a/core/sse_demo_4.py
+++ b/core/sse_demo_4.py
@@ -1,0 +1,34 @@
+from django.http import StreamingHttpResponse
+import psutil
+import time
+import json
+
+def system_stats_event_generator():
+    # Yield initial per-core usage, otherwise the first overall reading can be skewed
+    psutil.cpu_percent(percpu=True, interval=None)
+    time.sleep(0.1) # Short delay before starting the loop
+
+    while True:
+        cpu_overall_percent = psutil.cpu_percent(interval=1, percpu=False)
+        cpu_per_core_percent = psutil.cpu_percent(interval=None, percpu=True) # Get subsequent per-core without blocking for interval
+        memory_stats = psutil.virtual_memory()
+        memory_percent = memory_stats.percent
+
+        data = {
+            "cpu_overall_percent": cpu_overall_percent,
+            "cpu_per_core_percent": cpu_per_core_percent,
+            "memory_percent": memory_percent
+        }
+
+        # SSE format: event: <type>
+data: <json_string>
+
+
+        yield f"event: system_stats\ndata: {json.dumps(data)}\n\n"
+        # No need for additional time.sleep here as psutil.cpu_percent(interval=1) already introduces a delay
+
+def sse_system_stats(request):
+    response = StreamingHttpResponse(system_stats_event_generator(), content_type='text/event-stream')
+    response['Cache-Control'] = 'no-cache'
+    response['X-Accel-Buffering'] = 'no'  # For Nginx
+    return response

--- a/core/urls.py
+++ b/core/urls.py
@@ -21,6 +21,7 @@ from .health import health_check
 from .sse_demo import sse_demo
 from .sse_demo_2 import sse_demo_2
 from .sse_demo_3 import sse_demo_3
+from .sse_demo_4 import sse_system_stats
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -28,4 +29,5 @@ urlpatterns = [
     path('api/sse-demo', sse_demo, name='sse-demo'),
     path('api/sse-demo-2', sse_demo_2, name='sse-demo-2'),
     path('api/sse-demo-3', sse_demo_3, name='sse-demo-3'),
+    path('api/sse-system-stats', sse_system_stats, name='sse-system-stats'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ psycopg2-binary>=2.9.10
 django-cors-headers>=4.3.1
 requests>=2.31.0
 beautifulsoup4>=4.12.0
-lxml>=4.9.0 
+lxml>=4.9.0
+psutil>=5.9.0

--- a/sse-demo-client/src/App.js
+++ b/sse-demo-client/src/App.js
@@ -58,6 +58,20 @@ function Navigation() {
             >
               Web Scraping
             </Link>
+            <Link
+              to="/sse-system-stats"
+              style={{
+                color: 'white',
+                textDecoration: 'none',
+                padding: '8px 16px',
+                borderRadius: '6px',
+                transition: 'background-color 0.2s'
+              }}
+              onMouseOver={(e) => e.target.style.backgroundColor = '#34495e'}
+              onMouseOut={(e) => e.target.style.backgroundColor = 'transparent'}
+            >
+              System Stats
+            </Link>
           </div>
         </div>
       </div>
@@ -100,6 +114,35 @@ function HomePage() {
             }}
             onMouseOver={(e) => e.target.style.backgroundColor = '#2980b9'}
             onMouseOut={(e) => e.target.style.backgroundColor = '#3498db'}
+          >
+            Try Demo
+          </Link>
+        </div>
+
+        <div style={{
+          background: 'white',
+          padding: '24px',
+          borderRadius: '12px',
+          boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+          border: '1px solid #e0e0e0'
+        }}>
+          <h3 style={{ color: '#2c3e50', marginBottom: '12px' }}>System Resource Monitor</h3>
+          <p style={{ color: '#666', marginBottom: '16px' }}>
+            Streams real-time CPU and memory usage from the server.
+          </p>
+          <Link
+            to="/sse-system-stats"
+            style={{
+              display: 'inline-block',
+              background: '#f39c12',
+              color: 'white',
+              padding: '10px 20px',
+              borderRadius: '6px',
+              textDecoration: 'none',
+              transition: 'background-color 0.2s'
+            }}
+            onMouseOver={(e) => e.target.style.backgroundColor = '#e67e22'}
+            onMouseOut={(e) => e.target.style.backgroundColor = '#f39c12'}
           >
             Try Demo
           </Link>
@@ -193,6 +236,13 @@ function App() {
               endpoint="sse-demo-3"
               title="Web Scraping Demo"
               description="Real-time web scraping and content parsing. Fetches content from random websites and parses HTML, JSON, and XML."
+            />
+          } />
+          <Route path="/sse-system-stats" element={
+            <SSEDemo
+              endpoint="sse-system-stats"
+              title="System Resource Monitor"
+              description="Streams real-time CPU and memory usage from the server."
             />
           } />
           <Route path="*" element={<Navigate to="/" replace />} />


### PR DESCRIPTION
This commit introduces a new Server-Sent Events (SSE) demo that streams system resource metrics.

Features:
- A new Django backend endpoint `/api/sse-system-stats` is added (`core/sse_demo_4.py`).
- This endpoint uses the `psutil` library to fetch:
    - Overall CPU utilization percentage.
    - Per-core CPU utilization percentages.
    - Memory usage percentage.
- Metrics are streamed every second with the event type `system_stats`.
- `psutil` has been added to `requirements.txt`.

Frontend Updates:
- The React client (`sse-demo-client`) has been updated:
    - A new navigation link and homepage card for "System Stats" are added in `App.js`.
    - The `SSEDemo.js` component is enhanced to:
        - Handle `system_stats` events.
        - Display these metrics in a new dedicated `SystemStatsDisplay` component, showing progress bars for CPU and memory usage. - Conditionally renders the system stats UI only for this demo, hiding other irrelevant sections.

Documentation:
- `README.md` is updated to include details about the new demo, its API endpoint, and usage instructions.